### PR TITLE
fix: bypass system getaddrinfo(3) to prevent DNS failures in long-running processes

### DIFF
--- a/lib/clacky/agent/llm_caller.rb
+++ b/lib/clacky/agent/llm_caller.rb
@@ -211,7 +211,18 @@ module Clacky
           # connection after idle time). The Faraday connection object caches the
           # socket, so retrying without resetting it would hit the same dead socket.
           epipe = e.is_a?(Errno::EPIPE) || (e.respond_to?(:wrapped_exception) && e.wrapped_exception.is_a?(Errno::EPIPE))
-          @client.reset_connections! if epipe
+
+          # DNS resolution failures (getaddrinfo / "nodename nor servname")
+          # indicate a stale resolver context in long-running Ruby processes.
+          # On macOS, the mDNSResponder socket can become invalid after network
+          # configuration changes (WiFi reconnect, VPN, DHCP renew), causing
+          # getaddrinfo(3) to fail intermittently for the affected process.
+          # Resetting the Faraday connection forces Net::HTTP to re-initialize
+          # its underlying TCP socket, which acquires a fresh resolver context.
+          dns_failure = e.message.include?("getaddrinfo") ||
+                        e.message.include?("nodename nor servname")
+
+          @client.reset_connections! if epipe || dns_failure
 
           # Probing failure: primary still down — renew cooling-off and retry with fallback.
           if @config.probing?

--- a/lib/clacky/client.rb
+++ b/lib/clacky/client.rb
@@ -518,25 +518,22 @@ module Clacky
     # system getaddrinfo(3) resolver. On macOS, long-running processes can
     # develop a stale resolver context after network configuration changes
     # (WiFi reconnect, VPN, DHCP renew), causing getaddrinfo(3) to return
-    # EAI_NONAME ("nodename nor servname provided, or not known")
-    # intermittently. Resolv::DNS speaks DNS protocol directly over UDP,
-    # completely independent of the system resolver daemon (mDNSResponder).
+    # EAI_NONAME intermittently. Resolv::DNS speaks DNS protocol directly
+    # over UDP, independent of the system resolver daemon (mDNSResponder).
     #
-    # Falls back to the original URL on resolution failure so the system
-    # resolver still gets a chance.
-    private def resolve_host_once(url)
+    # Returns the resolved IP string, or nil on failure (caller falls back
+    # to system resolver via Net::HTTP's default behaviour).
+    private def resolve_host_ip(url)
       uri = URI.parse(url.to_s)
       hostname = uri.host
-      return url unless hostname && !hostname.match?(/\A\d+\.\d+\.\d+\.\d+\z/)
+      return nil unless hostname && !hostname.match?(/\A\d+\.\d+\.\d+\.\d+\z/)
 
-      ip = Resolv::DNS.new.getaddress(hostname).to_s
-      resolved = url.to_s.sub(hostname, ip)
-      resolved
+      Resolv::DNS.new.getaddress(hostname).to_s
     rescue Resolv::ResolvError, Resolv::ResolvTimeout => e
       if defined?(Clacky::Logger)
         Clacky::Logger.warn("[dns] #{hostname}: #{e.message}, falling back to system resolver")
       end
-      url
+      nil
     end
 
     def reset_connections!
@@ -549,15 +546,20 @@ module Clacky
       current_epoch = Clacky::ProxyConfig.epoch
       if @bedrock_connection.nil? ||
          (!@bedrock_connection_epoch.nil? && @bedrock_connection_epoch != current_epoch)
-        resolved_url = resolve_host_once(@base_url)
-        @bedrock_connection = Faraday.new(url: resolved_url) do |conn|
+        resolved_ip = resolve_host_ip(@base_url)
+        @bedrock_connection = Faraday.new(url: @base_url) do |conn|
           conn.headers["Content-Type"]  = "application/json"
           conn.headers["Authorization"] = "Bearer #{@api_key}"
-          conn.headers["Host"] = URI.parse(@base_url.to_s).host if resolved_url != @base_url.to_s
           conn.options.timeout      = @read_timeout || 300
           conn.options.open_timeout = 10
           conn.ssl.verify           = false
-          conn.adapter Faraday.default_adapter
+          if resolved_ip
+            conn.adapter :net_http do |http|
+              http.ipaddr = resolved_ip
+            end
+          else
+            conn.adapter Faraday.default_adapter
+          end
         end
         @bedrock_connection_epoch = current_epoch
       end
@@ -568,15 +570,20 @@ module Clacky
       current_epoch = Clacky::ProxyConfig.epoch
       if @openai_connection.nil? ||
          (!@openai_connection_epoch.nil? && @openai_connection_epoch != current_epoch)
-        resolved_url = resolve_host_once(@base_url)
-        @openai_connection = Faraday.new(url: resolved_url) do |conn|
+        resolved_ip = resolve_host_ip(@base_url)
+        @openai_connection = Faraday.new(url: @base_url) do |conn|
           conn.headers["Content-Type"]  = "application/json"
           conn.headers["Authorization"] = "Bearer #{@api_key}"
-          conn.headers["Host"] = URI.parse(@base_url.to_s).host if resolved_url != @base_url.to_s
           conn.options.timeout      = @read_timeout || 300
           conn.options.open_timeout = 10
           conn.ssl.verify           = false
-          conn.adapter Faraday.default_adapter
+          if resolved_ip
+            conn.adapter :net_http do |http|
+              http.ipaddr = resolved_ip
+            end
+          else
+            conn.adapter Faraday.default_adapter
+          end
         end
         @openai_connection_epoch = current_epoch
       end
@@ -587,8 +594,8 @@ module Clacky
       current_epoch = Clacky::ProxyConfig.epoch
       if @anthropic_connection.nil? ||
          (!@anthropic_connection_epoch.nil? && @anthropic_connection_epoch != current_epoch)
-        resolved_url = resolve_host_once(@base_url)
-        @anthropic_connection = Faraday.new(url: resolved_url) do |conn|
+        resolved_ip = resolve_host_ip(@base_url)
+        @anthropic_connection = Faraday.new(url: @base_url) do |conn|
           conn.headers["Content-Type"]   = "application/json"
           conn.headers["x-api-key"]      = @api_key
           conn.headers["anthropic-version"] = "2023-06-01"
@@ -601,11 +608,16 @@ module Clacky
           if @provider_id == "kimi-coding"
             conn.headers["User-Agent"] = "claude-cli/1.0.51 (external, cli)"
           end
-          conn.headers["Host"] = URI.parse(@base_url.to_s).host if resolved_url != @base_url.to_s
           conn.options.timeout      = @read_timeout || 300
           conn.options.open_timeout = 10
           conn.ssl.verify           = false
-          conn.adapter Faraday.default_adapter
+          if resolved_ip
+            conn.adapter :net_http do |http|
+              http.ipaddr = resolved_ip
+            end
+          else
+            conn.adapter Faraday.default_adapter
+          end
         end
         @anthropic_connection_epoch = current_epoch
       end

--- a/lib/clacky/client.rb
+++ b/lib/clacky/client.rb
@@ -2,6 +2,7 @@
 
 require "faraday"
 require "json"
+require "resolv"
 
 module Clacky
   class Client
@@ -513,6 +514,31 @@ module Clacky
       end
     end
 
+    # Pre-resolve hostname to IP using Ruby's Resolv::DNS, bypassing the
+    # system getaddrinfo(3) resolver. On macOS, long-running processes can
+    # develop a stale resolver context after network configuration changes
+    # (WiFi reconnect, VPN, DHCP renew), causing getaddrinfo(3) to return
+    # EAI_NONAME ("nodename nor servname provided, or not known")
+    # intermittently. Resolv::DNS speaks DNS protocol directly over UDP,
+    # completely independent of the system resolver daemon (mDNSResponder).
+    #
+    # Falls back to the original URL on resolution failure so the system
+    # resolver still gets a chance.
+    private def resolve_host_once(url)
+      uri = URI.parse(url.to_s)
+      hostname = uri.host
+      return url unless hostname && !hostname.match?(/\A\d+\.\d+\.\d+\.\d+\z/)
+
+      ip = Resolv::DNS.new.getaddress(hostname).to_s
+      resolved = url.to_s.sub(hostname, ip)
+      resolved
+    rescue Resolv::ResolvError, Resolv::ResolvTimeout => e
+      if defined?(Clacky::Logger)
+        Clacky::Logger.warn("[dns] #{hostname}: #{e.message}, falling back to system resolver")
+      end
+      url
+    end
+
     def reset_connections!
       @bedrock_connection = nil
       @openai_connection = nil
@@ -523,9 +549,11 @@ module Clacky
       current_epoch = Clacky::ProxyConfig.epoch
       if @bedrock_connection.nil? ||
          (!@bedrock_connection_epoch.nil? && @bedrock_connection_epoch != current_epoch)
-        @bedrock_connection = Faraday.new(url: @base_url) do |conn|
+        resolved_url = resolve_host_once(@base_url)
+        @bedrock_connection = Faraday.new(url: resolved_url) do |conn|
           conn.headers["Content-Type"]  = "application/json"
           conn.headers["Authorization"] = "Bearer #{@api_key}"
+          conn.headers["Host"] = URI.parse(@base_url.to_s).host if resolved_url != @base_url.to_s
           conn.options.timeout      = @read_timeout || 300
           conn.options.open_timeout = 10
           conn.ssl.verify           = false
@@ -540,9 +568,11 @@ module Clacky
       current_epoch = Clacky::ProxyConfig.epoch
       if @openai_connection.nil? ||
          (!@openai_connection_epoch.nil? && @openai_connection_epoch != current_epoch)
-        @openai_connection = Faraday.new(url: @base_url) do |conn|
+        resolved_url = resolve_host_once(@base_url)
+        @openai_connection = Faraday.new(url: resolved_url) do |conn|
           conn.headers["Content-Type"]  = "application/json"
           conn.headers["Authorization"] = "Bearer #{@api_key}"
+          conn.headers["Host"] = URI.parse(@base_url.to_s).host if resolved_url != @base_url.to_s
           conn.options.timeout      = @read_timeout || 300
           conn.options.open_timeout = 10
           conn.ssl.verify           = false
@@ -557,7 +587,8 @@ module Clacky
       current_epoch = Clacky::ProxyConfig.epoch
       if @anthropic_connection.nil? ||
          (!@anthropic_connection_epoch.nil? && @anthropic_connection_epoch != current_epoch)
-        @anthropic_connection = Faraday.new(url: @base_url) do |conn|
+        resolved_url = resolve_host_once(@base_url)
+        @anthropic_connection = Faraday.new(url: resolved_url) do |conn|
           conn.headers["Content-Type"]   = "application/json"
           conn.headers["x-api-key"]      = @api_key
           conn.headers["anthropic-version"] = "2023-06-01"
@@ -570,6 +601,7 @@ module Clacky
           if @provider_id == "kimi-coding"
             conn.headers["User-Agent"] = "claude-cli/1.0.51 (external, cli)"
           end
+          conn.headers["Host"] = URI.parse(@base_url.to_s).host if resolved_url != @base_url.to_s
           conn.options.timeout      = @read_timeout || 300
           conn.options.open_timeout = 10
           conn.ssl.verify           = false

--- a/lib/clacky/client.rb
+++ b/lib/clacky/client.rb
@@ -528,7 +528,7 @@ module Clacky
       hostname = uri.host
       return nil unless hostname && !hostname.match?(/\A\d+\.\d+\.\d+\.\d+\z/)
 
-      Resolv::DNS.new.getaddress(hostname).to_s
+      Resolv::DNS.open { |dns| dns.getaddress(hostname).to_s }
     rescue Resolv::ResolvError, Resolv::ResolvTimeout => e
       if defined?(Clacky::Logger)
         Clacky::Logger.warn("[dns] #{hostname}: #{e.message}, falling back to system resolver")


### PR DESCRIPTION
## Problem

openclacky 在 macOS 上运行较长时间（数小时）后，经常出现如下网络错误并触发重试：

```
正在重试: Network failed: Failed to open TCP connection to api.deepseek.com:443
(getaddrinfo(3): nodename nor servname provided, or not known) (4/10)…
```

同样错误也出现在其他远端 API 域名，如 `ark.cn-beijing.volces.com`、`ollama.com` 等。每次重试间隔 5 秒，最多 10 次，严重时导致请求失败。

## Root Cause

问题不在文件描述符耗尽或端口耗尽，而在 **macOS 系统 DNS 解析器的进程级状态污染**。

**调用链**：

```
openclacky → Faraday → Net::HTTP → TCPSocket → getaddrinfo(3) → mDNSResponder
```

`getaddrinfo(3)` 是 C 标准库的 DNS 解析函数。在 macOS 上，它通过 Unix socket 与 `mDNSResponder` 守护进程通信。当系统经历网络配置变更（WiFi 重连、VPN 连接/断开、DHCP 续租、休眠唤醒）时，长驻进程持有的 mDNSResponder socket 引用可能变为无效状态，导致 `getaddrinfo(3)` 间歇性返回 `EAI_NONAME`。

**为什么只有 openclacky 受影响？**

| 进程 | 网络层 | 为何不受影响 |
|------|--------|-------------|
| Chrome / 浏览器 | AsyncDNS | 独立 DNS 实现，不依赖系统 getaddrinfo |
| Node.js 进程 | `dns.lookup()` 线程池 | 独立 DNS 缓存和重试 |
| 系统短连接 | 短生命周期 | 连接不跨网络变更周期 |
| **openclacky (Ruby)** | `getaddrinfo(3)` 直通 | **唯一暴露系统 DNS bug 的路径** |

## Fix — Two-Layer Defense

### Layer 1: `client.rb` — 应用层 DNS 预解析

在 Faraday 建立连接时，使用 Ruby 标准库的 `Resolv::DNS` 做 DNS 解析。`Resolv::DNS` 是纯 Ruby 的 DNS 客户端，通过 UDP 直接与 DNS 服务器通信，**完全独立于 mDNSResponder**。

解析出的 IP 通过 Faraday adapter 回调设置到 `Net::HTTP#ipaddr`。Net::HTTP 会直连该 IP 但保留原始域名用于 TLS SNI 和 Host header，完全绕过 `getaddrinfo(3)` 且对上层调用透明。

失败时返回 nil，Net::HTTP 回退到系统解析器。

### Layer 2: `llm_caller.rb` — DNS 错误时强制重建连接

检测 `Faraday::ConnectionFailed` 中的 `getaddrinfo` / `nodename nor servname` 关键字，触发 `@client.reset_connections!`，强制下次重试用全新的 Faraday/Net::HTTP 连接对象，获取新的 resolver 上下文。

## Changes

- `lib/clacky/client.rb`: 新增 `require "resolv"`、`resolve_host_ip` 方法，三个 connection builder 通过 `conn.adapter :net_http { |http| http.ipaddr = ip }` 注入预解析 IP
- `lib/clacky/agent/llm_caller.rb`: DNS 错误检测 + `reset_connections!` 触发

## Verification

- [x] Ruby syntax check: both files pass
- [x] `Resolv::DNS` resolves API hostnames correctly (verified on macOS)
- [x] All 50 related specs pass (client, llm_caller, streaming, fallback)
- [x] No URL rewriting — `connection.url_prefix` stays intact for downstream consumers
- [x] Compatible with Ruby 2.6+ (stdlib-only, no gem dependency)
- [x] Graceful degradation on Windows (falls back to system resolver)
