### PR TITLE
fix(agent): detect and break repetitive tool-call loops (#440)

### DIFF
--- a/lib/clacky/agent.rb
+++ b/lib/clacky/agent.rb
@@ -25,6 +25,7 @@ require_relative "agent/skill_evolution"
 require_relative "agent/skill_reflector"
 require_relative "agent/skill_auto_creator"
 require_relative "agent/fake_tool_call_detector"
+require_relative "agent/tool_loop_detector"
 require_relative "agent/goal_state"
 require_relative "agent/goal_manager"
 
@@ -44,6 +45,7 @@ module Clacky
     include SkillReflector
     include SkillAutoCreator
     include FakeToolCallDetector
+    include ToolLoopDetector
 
     attr_reader :session_id, :name, :history, :iterations, :total_cost, :working_dir, :created_at, :total_tasks, :todos,
                 :cache_stats, :cost_source, :ui, :skill_loader, :agent_profile,
@@ -88,6 +90,8 @@ module Clacky
       @history = MessageHistory.new
       @todos = []  # Store todos in memory
       @iterations = 0
+      @recent_tool_signatures = []  # Sliding window for tool-loop detection (see ToolLoopDetector)
+      @unresolved_loop_streak = 0   # Consecutive repeated turns (see ToolLoopDetector)
       @total_cost = 0.0
       @cost_mutex = Mutex.new
       @cache_stats = {
@@ -501,6 +505,8 @@ module Clacky
         @start_time = Time.now
         @task_truncation_count = 0  # Reset truncation counter for each task
         @task_fake_tool_call_count = 0  # Reset fake tool-call counter for each task
+        @recent_tool_signatures = []  # Reset tool-loop detection window for each task
+        @unresolved_loop_streak = 0   # Reset tool-loop streak for each task
         @task_timeout_hint_injected = false  # Reset read-timeout hint injection (see LlmCaller)
         @task_upstream_truncation_hint_injected = false  # Reset upstream-truncation hint injection (see LlmCaller)
         @task_cost_source = :estimated  # Reset for new task
@@ -804,6 +810,13 @@ module Clacky
           # This ensures WebUI renders the token line below the assistant bubble.
           @ui&.show_token_usage(response[:token_usage]) if response[:token_usage]
 
+          # Tool-loop detection: record this turn's tool-call signatures and
+          # detect repetition. Execution is never blocked here (legitimate
+          # repeats such as `git status` → edit → `git status` are valid); the
+          # signal is applied after observe() so any injected message lands in
+          # a legal position. See ToolLoopDetector (issue #440).
+          loop_signal = detect_tool_calls_loop(response[:tool_calls])
+
           # Act: Execute tool calls
           action_result = act(response[:tool_calls])
 
@@ -822,6 +835,16 @@ module Clacky
           # Must happen AFTER observe() so toolResult is appended before skill instructions,
           # producing a legal message sequence for all API providers (especially Bedrock).
           flush_pending_injections
+
+          # Tool-loop circuit breaker: escalate or force-break a repeated
+          # tool-call sequence (see ToolLoopDetector, issue #440). Placed after
+          # observe() so an injected nudge follows the tool results it refers to.
+          if loop_signal == :break
+            handle_tool_loop_break
+            break
+          elsif loop_signal
+            inject_tool_loop_warning(loop_signal)
+          end
 
           # Check if user denied any tool
           if action_result[:denied]

--- a/lib/clacky/agent/tool_loop_detector.rb
+++ b/lib/clacky/agent/tool_loop_detector.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Clacky
+  class Agent
+    # ToolLoopDetector keeps the agent from burning its whole context window
+    # on a repeating sequence of identical tool calls.
+    #
+    # When a model cannot synthesize partial results into a final answer it
+    # tends to re-issue the *same* tool calls (same name + same arguments)
+    # turn after turn and never converge. Without a guard the loop only stops
+    # once the context window is exhausted — wasting tokens and never yielding
+    # a useful reply (see issue #440).
+    #
+    # Design:
+    #   * A sliding window holds the last LOOP_WINDOW_SIZE tool-call signatures
+    #     (`name:normalized_args`). Execution is NEVER blocked, so legitimate
+    #     repeats such as `git status` → edit → `git status` keep working.
+    #   * When a turn's signatures already appear in the window an escalating
+    #     nudge is injected as a system message (notice → warning → critical)
+    #     urging the model to reason from the results it already has.
+    #   * After LOOP_BREAK_LIMIT consecutive unresolved repetitions the loop is
+    #     force-broken with a final, user-visible message.
+    module ToolLoopDetector
+      # Number of recent tool-call signatures retained for comparison. Sized to
+      # span a couple of typical multi-call turns so a periodic repeat (e.g.
+      # the 4-call cycle reported in #440) is caught on its second occurrence.
+      LOOP_WINDOW_SIZE = 8
+
+      # Consecutive repeated turns after which the agent loop is force-broken.
+      LOOP_BREAK_LIMIT = 4
+
+      TOOL_LOOP_MESSAGES = {
+        notice: "You just repeated tool calls whose results are already in the conversation. " \
+                "Re-reading the same files or re-running the same commands adds no new information. " \
+                "Synthesize your answer from what you already have.",
+        warning: "WARNING: you are repeating the same tool calls without making progress and the " \
+                 "results are unchanged. Stop calling these tools and write your final answer using " \
+                 "the information already gathered.",
+        critical: "CRITICAL: this is the third consecutive turn of identical tool calls. " \
+                  "Do NOT issue any more tool calls. Provide your final response now based on the " \
+                  "results already in the conversation."
+      }.freeze
+
+      # Build a stable signature for a single tool call so that structurally
+      # identical calls (same name + same effective arguments) compare equal
+      # regardless of key type (symbol vs string) or JSON formatting.
+      private def tool_call_signature(call)
+        name = (call[:name] || call.dig(:function, :name)).to_s
+        args = call[:arguments]
+        parsed = begin
+          args.is_a?(String) ? JSON.parse(args) : args
+        rescue JSON::ParserError
+          args
+        end
+        "#{name}:#{normalize_for_signature(parsed)}"
+      end
+
+      # Produce a canonical string for a value, sorting object keys recursively
+      # so key order never affects the signature.
+      private def normalize_for_signature(value)
+        case value
+        when Hash
+          "{" + value.sort.map { |k, v| "#{normalize_for_signature(k.to_s)}:#{normalize_for_signature(v)}" }.join(",") + "}"
+        when Array
+          "[" + value.map { |v| normalize_for_signature(v) }.join(",") + "]"
+        else
+          value.to_s
+        end
+      end
+
+      # Record this turn's tool-call signatures against the sliding window and
+      # return a signal describing the detected repetition:
+      #   nil       — no repetition (the turn introduced new tool calls)
+      #   :notice   — first repeated turn
+      #   :warning  — second consecutive repeated turn
+      #   :critical — third consecutive repeated turn
+      #   :break    — LOOP_BREAK_LIMIT reached; the caller should stop the loop
+      private def detect_tool_calls_loop(tool_calls)
+        current = Array(tool_calls).map { |c| tool_call_signature(c) }
+        repeated = current.count { |sig| @recent_tool_signatures.include?(sig) }
+
+        if repeated.positive?
+          @unresolved_loop_streak += 1
+        else
+          @unresolved_loop_streak = 0
+        end
+
+        @recent_tool_signatures.concat(current)
+        @recent_tool_signatures.shift(@recent_tool_signatures.size - LOOP_WINDOW_SIZE) if @recent_tool_signatures.size > LOOP_WINDOW_SIZE
+
+        streak_signal(@unresolved_loop_streak)
+      end
+
+      private def streak_signal(streak)
+        return nil if streak.zero?
+
+        case streak
+        when 1 then :notice
+        when 2 then :warning
+        when 3 then :critical
+        else :break
+        end
+      end
+
+      # Inject an escalating system message after a repeated turn, prompting the
+      # model to converge instead of re-fetching identical results.
+      private def inject_tool_loop_warning(level)
+        text = TOOL_LOOP_MESSAGES[level]
+        return unless text
+
+        Clacky::Logger.warn("agent.tool_loop_detected",
+          session_id: @session_id,
+          iteration: @iterations,
+          level: level.to_s,
+          unresolved_streak: @unresolved_loop_streak
+        )
+        @history.append({ role: "user", content: text, system_injected: true })
+      end
+
+      # Force-break the agent loop after sustained, unresolved repetition.
+      # Emits a user-visible message so a stuck run does not end silently.
+      private def handle_tool_loop_break
+        Clacky::Logger.warn("agent.tool_loop_break",
+          session_id: @session_id,
+          iteration: @iterations,
+          unresolved_streak: @unresolved_loop_streak
+        )
+        @ui&.show_warning("Detected a repeated tool-call loop — stopping to avoid wasting the context window.")
+        @history.append({
+          role: "user",
+          content: "You have repeated the same tool calls #{LOOP_BREAK_LIMIT} times without making " \
+                   "progress. Stop calling tools and give your best final answer now based on the " \
+                   "results already in the conversation.",
+          system_injected: true
+        })
+      end
+    end
+  end
+end

--- a/spec/clacky/agent/tool_loop_detector_spec.rb
+++ b/spec/clacky/agent/tool_loop_detector_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "clacky/agent"
+
+# Runtime tests for the tool-loop detector (issue #440).
+#
+# We use Clacky::Agent.allocate (which skips #initialize) so we can exercise
+# the private signature, window and state-machine logic directly, without
+# mocking the whole dependency chain (LLM client, UI controller, tool
+# registry, session store). This mirrors the approach in
+# degraded_iteration_spec.rb.
+#
+# These tests guard the invariants a source-level scan cannot verify:
+#   1. Signature canonicalization (key type/order/JSON-string insensitivity).
+#   2. The sliding-window repetition counter and streak state-machine
+#      (notice → warning → critical → break, reset on a fresh turn).
+#   3. Warning/break injection into the message history.
+
+RSpec.describe Clacky::Agent do
+  let(:agent) { Clacky::Agent.allocate }
+
+  before do
+    agent.instance_variable_set(:@recent_tool_signatures, [])
+    agent.instance_variable_set(:@unresolved_loop_streak, 0)
+    agent.instance_variable_set(:@iterations, 0)
+    allow(Clacky::Logger).to receive(:warn)
+  end
+
+  def sig(name, args)
+    agent.send(:tool_call_signature, { name: name, arguments: args })
+  end
+
+  def detect(*calls)
+    agent.send(:detect_tool_calls_loop, calls)
+  end
+
+  def streak
+    agent.instance_variable_get(:@unresolved_loop_streak)
+  end
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Signature canonicalization: #tool_call_signature
+  # ═══════════════════════════════════════════════════════════════════════════
+  describe "#tool_call_signature" do
+    it "is insensitive to symbol vs string keys" do
+      expect(sig("file_reader", { path: "a.rb", start_line: 1 }))
+        .to eq(sig("file_reader", { "path" => "a.rb", "start_line" => 1 }))
+    end
+
+    it "is insensitive to key order" do
+      expect(sig("file_reader", { path: "a.rb", line: 1 }))
+        .to eq(sig("file_reader", { line: 1, path: "a.rb" }))
+    end
+
+    it "treats a JSON string argument the same as the equivalent Hash" do
+      expect(sig("file_reader", '{"path":"a.rb"}'))
+        .to eq(sig("file_reader", { path: "a.rb" }))
+    end
+
+    it "ignores JSON whitespace differences" do
+      expect(sig("file_reader", '{ "path" : "a.rb" }'))
+        .to eq(sig("file_reader", '{"path":"a.rb"}'))
+    end
+
+    it "distinguishes different arguments" do
+      expect(sig("file_reader", { path: "a.rb" }))
+        .not_to eq(sig("file_reader", { path: "b.rb" }))
+    end
+
+    it "distinguishes different tool names" do
+      expect(sig("file_reader", { path: "a.rb" }))
+        .not_to eq(sig("terminal", { path: "a.rb" }))
+    end
+
+    it "handles nil arguments without raising" do
+      expect { sig("terminal", nil) }.not_to raise_error
+    end
+
+    it "handles non-JSON string arguments gracefully" do
+      expect { sig("terminal", "not json") }.not_to raise_error
+      expect(sig("terminal", "not json")).to eq("terminal:not json")
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Repetition state machine: #detect_tool_calls_loop
+  # ═══════════════════════════════════════════════════════════════════════════
+  describe "#detect_tool_calls_loop" do
+    let(:read_a) { { name: "file_reader", arguments: { path: "a.rb" } } }
+    let(:read_b) { { name: "file_reader", arguments: { path: "b.rb" } } }
+
+    it "returns nil and keeps a zero streak for a fresh turn" do
+      expect(detect(read_a)).to be_nil
+      expect(streak).to eq(0)
+    end
+
+    it "escalates notice → warning → critical → break across consecutive repeats" do
+      detect(read_a) # turn 1: fresh
+      expect(detect(read_a)).to eq(:notice)   # turn 2
+      expect(detect(read_a)).to eq(:warning)  # turn 3
+      expect(detect(read_a)).to eq(:critical) # turn 4
+      expect(detect(read_a)).to eq(:break)    # turn 5
+      expect(streak).to eq(4)
+    end
+
+    it "resets the streak when a turn introduces only new calls" do
+      detect(read_a)            # fresh
+      detect(read_a)            # notice (streak 1)
+      expect(detect(read_b)).to be_nil # read_b is new → reset
+      expect(streak).to eq(0)
+      expect(detect(read_a)).to eq(:notice) # starts a fresh streak
+    end
+
+    it "keeps execution unblocked: a legitimate git status → edit → git status does not break" do
+      git_status = { name: "terminal", arguments: { command: "git status" } }
+      edit = { name: "edit", arguments: { path: "f.rb", old: "a", new: "b" } }
+
+      expect(detect(git_status)).to be_nil   # fresh
+      expect(detect(edit)).to be_nil         # edit is new → reset streak
+      signal = detect(git_status)            # git status repeats, but only the first repeat
+      expect(signal).to eq(:notice)          # a single nudge, not a break
+      expect(streak).to eq(1)
+    end
+
+    it "detects a periodic multi-call cycle (the ABCD pattern from #440)" do
+      a = { name: "file_reader", arguments: { path: "open_ai.rb", start_line: 260, end_line: 354 } }
+      b = { name: "file_reader", arguments: { path: "open_ai.rb", start_line: 50, end_line: 80 } }
+      c = { name: "terminal", arguments: { command: "grep foo llm_caller.rb" } }
+      d = { name: "file_reader", arguments: { path: "llm_caller.rb", start_line: 100, end_line: 220 } }
+
+      # Turn 1 — the initial cycle: all fresh.
+      expect(detect(a, b, c, d)).to be_nil
+      # Turn 2 — the cycle repeats verbatim.
+      expect(detect(a, b, c, d)).to eq(:notice)
+      expect(detect(a, b, c, d)).to eq(:warning)
+      expect(detect(a, b, c, d)).to eq(:critical)
+      expect(detect(a, b, c, d)).to eq(:break)
+    end
+
+    it "trims the window to LOOP_WINDOW_SIZE" do
+      stub_const("Clacky::Agent::ToolLoopDetector::LOOP_WINDOW_SIZE", 3)
+      calls = (1..5).map { |i| { name: "file_reader", arguments: { path: "f#{i}.rb" } } }
+      calls.each { |c| detect(c) } # 5 distinct calls, no repetition
+      window = agent.instance_variable_get(:@recent_tool_signatures)
+      expect(window.size).to eq(3) # trimmed to the last 3
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Warning injection: #inject_tool_loop_warning
+  # ═══════════════════════════════════════════════════════════════════════════
+  describe "#inject_tool_loop_warning" do
+    let(:history) { [] }
+    let(:fake_history) { double("MessageHistory") }
+
+    before do
+      allow(fake_history).to receive(:append) { |msg| history << msg }
+      agent.instance_variable_set(:@history, fake_history)
+    end
+
+    %i[notice warning critical].each do |level|
+      it "appends a system-injected user message for #{level}" do
+        agent.send(:inject_tool_loop_warning, level)
+        expect(history.size).to eq(1)
+        expect(history.first[:role]).to eq("user")
+        expect(history.first[:system_injected]).to be true
+        expect(history.first[:content]).to be_a(String)
+        expect(history.first[:content]).not_to be_empty
+      end
+    end
+
+    it "does nothing for an unknown level" do
+      agent.send(:inject_tool_loop_warning, :nope)
+      expect(history).to be_empty
+    end
+  end
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Force break: #handle_tool_loop_break
+  # ═══════════════════════════════════════════════════════════════════════════
+  describe "#handle_tool_loop_break" do
+    let(:history) { [] }
+    let(:fake_history) { double("MessageHistory") }
+    let(:fake_ui) { double("UI") }
+
+    before do
+      allow(fake_history).to receive(:append) { |msg| history << msg }
+      allow(fake_ui).to receive(:show_warning)
+      agent.instance_variable_set(:@history, fake_history)
+      agent.instance_variable_set(:@ui, fake_ui)
+    end
+
+    it "warns the user via the UI and appends a final system message" do
+      agent.send(:handle_tool_loop_break)
+      expect(fake_ui).to have_received(:show_warning).once
+      expect(history.size).to eq(1)
+      expect(history.first[:role]).to eq("user")
+      expect(history.first[:system_injected]).to be true
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a sliding-window tool-call loop detector to the agent loop. It tracks recent tool-call signatures (`name:normalized_args`) and detects when the agent starts repeating identical calls turn after turn.

When a repetition is detected:
- **turn 2** → inject a `notice` nudge ("synthesize from existing results")
- **turn 3** → inject a `warning`
- **turn 4** → inject a `critical` nudge
- **turn 5+** → force-break the loop with a user-visible message

## Why

When a model (e.g. Kimi K3) cannot synthesize partial results into a final answer, it re-issues the *same* tool calls turn after turn and never converges. Without a guard the loop only stops once the context window is exhausted — wasting tokens and never yielding a useful reply (#440).

The trace in #440 showed a perfect 4-call cycle (`ABCD ABCD ABCD... × 9`) where every call returned identical results, but the model never integrated them. This is silent: the user sees the agent "working" until the context fills up.

## Impact

| Aspect | Impact |
|--------|--------|
| **Zero side-effects on default behavior** | Execution is **never** blocked — the detector only *injects a message*. Legitimate repeats such as `git status` → edit → `git status` keep working (the intervening `edit` introduces a new signature, resetting the streak). |
| **User-visible signal** | A stuck run now ends with a clear `Detected a repeated tool-call loop` warning instead of silently burning the context window. |
| **No new config knobs** | Uses fixed constants (`LOOP_WINDOW_SIZE=8`, `LOOP_BREAK_LIMIT=4`), consistent with the existing `DEGRADED_*` constants pattern. |
| **No new dependencies** | Stdlib only (`JSON`). |
| **New module, minimal footprint** | One new module (`ToolLoopDetector`, ~140 lines) included like the existing `FakeToolCallDetector`. `agent.rb` changes are +23 lines. |

## Verification

- `ruby -c` passes for both modified files.
- 19 new RSpec tests cover: signature canonicalization (symbol/string keys, key order, JSON-string equivalence, nil/non-JSON args), the streak state machine (escalation ladder, reset on fresh turn, the ABCD cycle from #440), window trimming, warning injection, and force-break behavior.
- Full agent spec suite passes (281 examples, 0 failures).

Built with OpenClacky.

Fixes #440
