### PR TITLE
fix(terminal): kill the whole PTY process group on exit, not just the leader

### DIFF
--- a/lib/clacky/tools/terminal/session_manager.rb
+++ b/lib/clacky/tools/terminal/session_manager.rb
@@ -176,12 +176,15 @@ module Clacky
           end
 
           # Kill every live session and close any open fds. Called from at_exit.
+          # Signal the whole process group (-pid) so background `&` jobs
+          # and other grandchildren get reaped too. See issue #485.
           def kill_all!
-            (@sessions.values rescue []).each do |s|
+            @sessions.values.each do |s|
+              next if %w[exited killed].include?(s.status.to_s)
               begin
-                Process.kill("KILL", s.pid) unless %w[exited killed].include?(s.status.to_s)
-              rescue StandardError
-                # ignore
+                Process.kill("KILL", -s.pid)
+              rescue Errno::ESRCH
+                # group already gone
               end
               s.log_io&.close rescue nil
               s.writer&.close rescue nil

--- a/spec/clacky/tools/terminal/session_manager_process_group_spec.rb
+++ b/spec/clacky/tools/terminal/session_manager_process_group_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Regression tests for issue #485: kill_all! must reap the whole PTY
+# process group, not just the leader, so background `&` jobs and other
+# grandchildren don't outlive the openclacky process.
+
+RSpec.describe Clacky::Tools::Terminal::SessionManager, "process group cleanup (#485)" do
+  before { described_class.reset! }
+  after  { described_class.reset! }
+
+  let(:killed) { @killed ||= [] }
+
+  before do
+    counter = 100_000
+    allow(described_class).to receive(:register).and_wrap_original do |orig, **kw|
+      counter += 1
+      orig.call(**kw.merge(pid: counter))
+    end
+    allow(Process).to receive(:kill) do |sig, target|
+      killed << [sig, target]
+      1
+    end
+  end
+
+  def make_session
+    described_class.register(
+      command: "bash -l -i",
+      cwd: Dir.pwd,
+      log_file: "/dev/null",
+      log_io: File.open("/dev/null", "wb"),
+      reader: File.open("/dev/null", "rb"),
+      writer: File.open("/dev/null", "wb"),
+      reader_thread: Thread.new { sleep 60 },
+      mode: "shell",
+    )
+  end
+
+  it "signals the whole process group (negative pid)" do
+    s = make_session
+    described_class.kill_all!
+    expect(killed).to include(["KILL", -s.pid])
+  end
+
+  it "skips sessions that are already exited or killed" do
+    a = make_session
+    b = make_session
+    a.status = "exited"
+    b.status = "killed"
+    described_class.kill_all!
+    expect(killed).to be_empty
+  end
+end


### PR DESCRIPTION
Switch from `kill -pid` to `kill -pgid` so the PTY leader and every grandchild it spawned (background `&` jobs, sub-shells, etc.) get reaped together. Before, only the leader died and the grandchildren became orphans.

One-line change.

## Diff

```diff
- Process.kill("KILL", s.pid) unless %w[exited killed].include?(s.status.to_s)
+ next if %w[exited killed].include?(s.status.to_s)
+ Process.kill("KILL", -s.pid)
```

## Not fixed

`kill -9` is untrappable by design. Out of scope for this PR.

## Tested

- 2 new specs + the existing 112 in `terminal_spec.rb` → 114/114 pass on Ruby 4.0.5
- Manually verified with a real PTY spawning 1 bash + 3 backgrounded `sleep 30`s: one `kill -pgid` reaps all four
